### PR TITLE
feat: navigation can cycle through root board position

### DIFF
--- a/src/lib/ui-state/index.ts
+++ b/src/lib/ui-state/index.ts
@@ -65,17 +65,22 @@ export const displayMoveInHistory = (
 			if (typeof variantMoves[moveIndex + offset] !== 'undefined') {
 				moveToDisplay = variantMoves[moveIndex + offset];
 			}
+
+			if (typeof moveToDisplay === 'undefined') {
+				moveToDisplay = moves[variant.parentMoveIndex + offset];
+			}
 		} else {
 			if (typeof moves[moveIndex + offset] !== 'undefined') {
 				moveToDisplay = moves[moveIndex + offset];
 			}
 		}
+	} else if (offset < 0) {
+	  moveToDisplay = draft.study.moves[draft.study.moves.length - 1];
+	} else if (offset > 0) {
+	  moveToDisplay = draft.study.moves[0];
+	}
 
-		if (!moveToDisplay) {
-			console.log(`No move to display found`);
-			return draft;
-		}
-
+	if (moveToDisplay) {
 		const chess = new Chess(moveToDisplay.after);
 
 		chessView.set({
@@ -92,6 +97,26 @@ export const displayMoveInHistory = (
 		draft.currentMove = moveToDisplay;
 
 		setChessLogic(chess);
+	} else if (offset !== 0){
+		const chess = draft.study.root.fen ? new Chess(draft.study.root.fen) : new Chess();
+
+		chessView.set({
+		  fen: chess.fen(),
+			check: chess.isCheck(),
+			movable: {
+				free: false,
+				color: toColor(chess),
+				dests: toDests(chess),
+			},
+			turnColor: toColor(chess),
+		});
+
+		draft.currentMove = null;
+
+		setChessLogic(chess);
+	} else {
+		console.log(`No move to display found`);
+		return draft;
 	}
 
 	return draft;


### PR DESCRIPTION
This fixes the navigation logic so that users can use the left and right navigation arrows to cycle through the root board position and then to the first or last move. I also fixed a few bugs in the code. There were a few lines that assumed that the saved chess file study data would have a rootFEN, but they won't if they already exist. The error reporting for PGN parsing should have said FEN/PGN parsing.